### PR TITLE
CVE base-image hardening; bump published version to 1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Retrieve the Deepgram Self-Hosted Starter image references:
 
 ```bash
 export IMAGE_REPO=gcr.io/deepgram-public/deepgram-self-hosted-starter
-export IMAGE_TAG=1.6.0
+export IMAGE_TAG=1.2.0
 ```
 
 Install the app with Helm:
@@ -68,7 +68,7 @@ The Deepgram Self-Hosted Starter does not persist any data. Backup and restore p
 To update the application with a new image version, set the new tag:
 
 ```bash
-export NEW_IMAGE_TAG=1.6.0
+export NEW_IMAGE_TAG=1.2.0
 ```
 
 Update the Deployment with the new image:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Retrieve the Deepgram Self-Hosted Starter image references:
 
 ```bash
 export IMAGE_REPO=gcr.io/deepgram-public/deepgram-self-hosted-starter
-export IMAGE_TAG=1.2.0
+export IMAGE_TAG=1.2.1
 ```
 
 Install the app with Helm:
@@ -68,7 +68,7 @@ The Deepgram Self-Hosted Starter does not persist any data. Backup and restore p
 To update the application with a new image version, set the new tag:
 
 ```bash
-export NEW_IMAGE_TAG=1.2.0
+export NEW_IMAGE_TAG=1.2.1
 ```
 
 Update the Deployment with the new image:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Retrieve the Deepgram Self-Hosted Starter image references:
 
 ```bash
 export IMAGE_REPO=gcr.io/deepgram-public/deepgram-self-hosted-starter
-export IMAGE_TAG=1.2.1
+export IMAGE_TAG=1.2.2
 ```
 
 Install the app with Helm:
@@ -68,7 +68,7 @@ The Deepgram Self-Hosted Starter does not persist any data. Backup and restore p
 To update the application with a new image version, set the new tag:
 
 ```bash
-export NEW_IMAGE_TAG=1.2.1
+export NEW_IMAGE_TAG=1.2.2
 ```
 
 Update the Deployment with the new image:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Retrieve the Deepgram Self-Hosted Starter image references:
 
 ```bash
 export IMAGE_REPO=gcr.io/deepgram-public/deepgram-self-hosted-starter
-export IMAGE_TAG=1.1.7
+export IMAGE_TAG=1.6.0
 ```
 
 Install the app with Helm:
@@ -68,7 +68,7 @@ The Deepgram Self-Hosted Starter does not persist any data. Backup and restore p
 To update the application with a new image version, set the new tag:
 
 ```bash
-export NEW_IMAGE_TAG=2.0.0
+export NEW_IMAGE_TAG=1.6.0
 ```
 
 Update the Deployment with the new image:

--- a/apptest/deployer/schema.yaml
+++ b/apptest/deployer/schema.yaml
@@ -1,6 +1,6 @@
 properties:
   testerImage:
     type: string
-    default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester:1.2.1
+    default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester:1.2.2
     x-google-property:
       type: IMAGE

--- a/apptest/deployer/schema.yaml
+++ b/apptest/deployer/schema.yaml
@@ -1,6 +1,6 @@
 properties:
   testerImage:
     type: string
-    default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester:1.2.0
+    default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester:1.2.1
     x-google-property:
       type: IMAGE

--- a/apptest/deployer/schema.yaml
+++ b/apptest/deployer/schema.yaml
@@ -1,6 +1,6 @@
 properties:
   testerImage:
     type: string
-    default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester:1.6.0
+    default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester:1.2.0
     x-google-property:
       type: IMAGE

--- a/apptest/deployer/schema.yaml
+++ b/apptest/deployer/schema.yaml
@@ -1,6 +1,6 @@
 properties:
   testerImage:
     type: string
-    default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester:1.5.2
+    default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester:1.6.0
     x-google-property:
       type: IMAGE

--- a/apptest/deployer/schema.yaml
+++ b/apptest/deployer/schema.yaml
@@ -1,6 +1,6 @@
 properties:
   testerImage:
     type: string
-    default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester:1.1.7
+    default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester:1.5.2
     x-google-property:
       type: IMAGE

--- a/apptest/tester/Dockerfile
+++ b/apptest/tester/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/cloud-marketplace-tools/testrunner:0.1.8
 
 RUN apt-get update && \
-  apt-get upgrade -y && \
+  apt-get dist-upgrade -y && \
   apt-get install -y --no-install-recommends \
   ca-certificates \
   curl

--- a/apptest/tester/Dockerfile
+++ b/apptest/tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-marketplace-tools/testrunner:0.1.5
+FROM gcr.io/cloud-marketplace-tools/testrunner:0.1.8
 
 RUN apt-get update && \
   apt-get upgrade -y && \

--- a/bump.sh
+++ b/bump.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# bump.sh — Update all version references in gcp-marketplace-listing to a
+# new release version.
+#
+# Usage:
+#   ./bump.sh <version>
+#
+# Arguments:
+#   version  Full semver tag, e.g. 1.6.0
+#
+# Files updated:
+#   schema.yaml                                         (publishedVersion, image tag defaults)
+#   apptest/deployer/schema.yaml                        (testerImage full reference)
+#   chart/deepgram-self-hosted-starter/Chart.yaml       (version, appVersion)
+#   README.md                                           (IMAGE_TAG example)
+#
+# This script is idempotent: running it twice with the same version produces
+# the same result. It is called by build.sh in gcp-marketplace-listing-internal
+# as the first step of a release build, but can also be run standalone to
+# prepare a version bump commit independently of building.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+usage() {
+    echo "Usage: $0 <version>"
+    echo "  Example: $0 1.6.0"
+    exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+    usage
+fi
+
+NEW_TAG="$1"
+
+if [[ ! "$NEW_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: version must be in major.minor.patch format (e.g. 1.6.0)"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Portable in-place sed (BSD sed on macOS requires an empty-string extension)
+# ---------------------------------------------------------------------------
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    SED_INPLACE=(-i '')
+else
+    SED_INPLACE=(-i)
+fi
+
+# Resolve repo root from the script's own location so this works whether
+# called directly or via an absolute path from build.sh.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> Bumping version references to $NEW_TAG"
+
+# ---------------------------------------------------------------------------
+# schema.yaml
+#
+# Three fields updated:
+#   publishedVersion: X.Y.Z
+#   deepgramSelfHostedStarter.image.tag  default: X.Y.Z
+#   tester.image.tag                     default: X.Y.Z
+#
+# The pattern `default: [0-9][0-9.]*` is safe here because all other
+# `default:` values in this file begin with `gcr.io/` and will not match.
+# ---------------------------------------------------------------------------
+
+sed "${SED_INPLACE[@]}" \
+    -e "s/publishedVersion: [0-9][0-9.]*/publishedVersion: $NEW_TAG/" \
+    -e "s/\(default: \)[0-9][0-9.]*/\1$NEW_TAG/g" \
+    "$REPO_ROOT/schema.yaml"
+
+# ---------------------------------------------------------------------------
+# apptest/deployer/schema.yaml
+#
+# Updates the testerImage full reference:
+#   default: .../deployer/tester:X.Y.Z
+# ---------------------------------------------------------------------------
+
+sed "${SED_INPLACE[@]}" \
+    -e "s|deployer/tester:[0-9][0-9.]*|deployer/tester:$NEW_TAG|" \
+    "$REPO_ROOT/apptest/deployer/schema.yaml"
+
+# ---------------------------------------------------------------------------
+# chart/deepgram-self-hosted-starter/Chart.yaml
+#
+# Updates version and appVersion fields.
+# Anchored to line start (^) to avoid matching keys like `kubeVersion`.
+# ---------------------------------------------------------------------------
+
+sed "${SED_INPLACE[@]}" \
+    -e "s/^version: [0-9][0-9.]*/version: $NEW_TAG/" \
+    -e "s/^appVersion: [0-9][0-9.]*/appVersion: $NEW_TAG/" \
+    "$REPO_ROOT/chart/deepgram-self-hosted-starter/Chart.yaml"
+
+# ---------------------------------------------------------------------------
+# README.md
+#
+# Updates the IMAGE_TAG example in the installation instructions.
+# ---------------------------------------------------------------------------
+
+sed "${SED_INPLACE[@]}" \
+    -e "s/IMAGE_TAG=[0-9][0-9.]*/IMAGE_TAG=$NEW_TAG/" \
+    "$REPO_ROOT/README.md"
+
+echo "    schema.yaml"
+echo "    apptest/deployer/schema.yaml"
+echo "    chart/deepgram-self-hosted-starter/Chart.yaml"
+echo "    README.md"

--- a/chart/deepgram-self-hosted-starter/Chart.yaml
+++ b/chart/deepgram-self-hosted-starter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: deepgram-self-hosted-starter
 type: application
-version: 1.2.0
-appVersion: 1.2.0
+version: 1.2.1
+appVersion: 1.2.1
 description: A Helm chart for running a starter Deepgram application in a self-hosted environment
 sources: ["https://github.com/deepgram/gcp-marketplace-listing"]
 kubeVersion: ">=1.27.0-0"

--- a/chart/deepgram-self-hosted-starter/Chart.yaml
+++ b/chart/deepgram-self-hosted-starter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: deepgram-self-hosted-starter
 type: application
-version: 1.6.0
-appVersion: 1.6.0
+version: 1.2.0
+appVersion: 1.2.0
 description: A Helm chart for running a starter Deepgram application in a self-hosted environment
 sources: ["https://github.com/deepgram/gcp-marketplace-listing"]
 kubeVersion: ">=1.27.0-0"

--- a/chart/deepgram-self-hosted-starter/Chart.yaml
+++ b/chart/deepgram-self-hosted-starter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: deepgram-self-hosted-starter
 type: application
-version: 1.1.7
-appVersion: 1.1.7
+version: 1.5.2
+appVersion: 1.5.2
 description: A Helm chart for running a starter Deepgram application in a self-hosted environment
 sources: ["https://github.com/deepgram/gcp-marketplace-listing"]
 kubeVersion: ">=1.27.0-0"

--- a/chart/deepgram-self-hosted-starter/Chart.yaml
+++ b/chart/deepgram-self-hosted-starter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: deepgram-self-hosted-starter
 type: application
-version: 1.2.1
-appVersion: 1.2.1
+version: 1.2.2
+appVersion: 1.2.2
 description: A Helm chart for running a starter Deepgram application in a self-hosted environment
 sources: ["https://github.com/deepgram/gcp-marketplace-listing"]
 kubeVersion: ">=1.27.0-0"

--- a/chart/deepgram-self-hosted-starter/Chart.yaml
+++ b/chart/deepgram-self-hosted-starter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: deepgram-self-hosted-starter
 type: application
-version: 1.5.2
-appVersion: 1.5.2
+version: 1.6.0
+appVersion: 1.6.0
 description: A Helm chart for running a starter Deepgram application in a self-hosted environment
 sources: ["https://github.com/deepgram/gcp-marketplace-listing"]
 kubeVersion: ">=1.27.0-0"

--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -1,4 +1,4 @@
-FROM marketplace.gcr.io/google/c2d-debian11 AS build
+FROM marketplace.gcr.io/google/c2d-debian11:latest AS build
 
 RUN apt-get update \
   && apt-get upgrade -y \

--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -24,6 +24,7 @@ RUN cat /tmp/apptest/schema.yaml > /tmp/apptest/schema.yaml.new \
   && mv /tmp/apptest/schema.yaml.new /tmp/apptest/schema.yaml
 
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:latest
+RUN apt-get update && apt-get dist-upgrade -y && rm -rf /var/lib/apt/lists/*
 COPY --from=build /tmp/deepgram-self-hosted-starter.tar.gz /data/chart/
 COPY --from=build /tmp/test/deepgram-self-hosted-starter.tar.gz /data-test/chart/
 COPY --from=build /tmp/apptest/schema.yaml /data-test/

--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -1,7 +1,7 @@
 FROM marketplace.gcr.io/google/c2d-debian11:latest AS build
 
 RUN apt-get update \
-  && apt-get upgrade -y \
+  && apt-get dist-upgrade -y \
   && apt-get install -y --no-install-recommends gettext
 
 ADD chart/deepgram-self-hosted-starter /tmp/chart

--- a/schema.yaml
+++ b/schema.yaml
@@ -3,7 +3,7 @@ x-google-marketplace:
 
   applicationApiVersion: v1beta1
 
-  publishedVersion: 1.2.0
+  publishedVersion: 1.2.1
   publishedVersionMetadata:
     releaseNote: >-
       A regular update.
@@ -26,7 +26,7 @@ x-google-marketplace:
           default: gcr.io/deepgram-public/deepgram-self-hosted-starter
         deepgramSelfHostedStarter.image.tag:
           type: TAG
-          default: 1.2.0
+          default: 1.2.1
     ubbagent:
       properties:
         ubbagentFull:
@@ -39,7 +39,7 @@ x-google-marketplace:
           default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester
         tester.image.tag:
           type: TAG
-          default: 1.2.0
+          default: 1.2.1
 
 properties:
   name:

--- a/schema.yaml
+++ b/schema.yaml
@@ -3,7 +3,7 @@ x-google-marketplace:
 
   applicationApiVersion: v1beta1
 
-  publishedVersion: 1.6.0
+  publishedVersion: 1.2.0
   publishedVersionMetadata:
     releaseNote: >-
       A regular update.
@@ -26,7 +26,7 @@ x-google-marketplace:
           default: gcr.io/deepgram-public/deepgram-self-hosted-starter
         deepgramSelfHostedStarter.image.tag:
           type: TAG
-          default: 1.6.0
+          default: 1.2.0
     ubbagent:
       properties:
         ubbagentFull:
@@ -39,7 +39,7 @@ x-google-marketplace:
           default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester
         tester.image.tag:
           type: TAG
-          default: 1.6.0
+          default: 1.2.0
 
 properties:
   name:

--- a/schema.yaml
+++ b/schema.yaml
@@ -3,7 +3,7 @@ x-google-marketplace:
 
   applicationApiVersion: v1beta1
 
-  publishedVersion: 1.2.1
+  publishedVersion: 1.2.2
   publishedVersionMetadata:
     releaseNote: >-
       A regular update.
@@ -26,7 +26,7 @@ x-google-marketplace:
           default: gcr.io/deepgram-public/deepgram-self-hosted-starter
         deepgramSelfHostedStarter.image.tag:
           type: TAG
-          default: 1.2.1
+          default: 1.2.2
     ubbagent:
       properties:
         ubbagentFull:
@@ -39,7 +39,7 @@ x-google-marketplace:
           default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester
         tester.image.tag:
           type: TAG
-          default: 1.2.1
+          default: 1.2.2
 
 properties:
   name:

--- a/schema.yaml
+++ b/schema.yaml
@@ -3,7 +3,7 @@ x-google-marketplace:
 
   applicationApiVersion: v1beta1
 
-  publishedVersion: 1.1.7
+  publishedVersion: 1.5.2
   publishedVersionMetadata:
     releaseNote: >-
       A regular update.
@@ -26,7 +26,7 @@ x-google-marketplace:
           default: gcr.io/deepgram-public/deepgram-self-hosted-starter
         deepgramSelfHostedStarter.image.tag:
           type: TAG
-          default: 1.1.7
+          default: 1.5.2
     ubbagent:
       properties:
         ubbagentFull:
@@ -39,7 +39,7 @@ x-google-marketplace:
           default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester
         tester.image.tag:
           type: TAG
-          default: 1.1.7
+          default: 1.5.2
 
 properties:
   name:

--- a/schema.yaml
+++ b/schema.yaml
@@ -3,7 +3,7 @@ x-google-marketplace:
 
   applicationApiVersion: v1beta1
 
-  publishedVersion: 1.5.2
+  publishedVersion: 1.6.0
   publishedVersionMetadata:
     releaseNote: >-
       A regular update.
@@ -26,7 +26,7 @@ x-google-marketplace:
           default: gcr.io/deepgram-public/deepgram-self-hosted-starter
         deepgramSelfHostedStarter.image.tag:
           type: TAG
-          default: 1.5.2
+          default: 1.6.0
     ubbagent:
       properties:
         ubbagentFull:
@@ -39,7 +39,7 @@ x-google-marketplace:
           default: gcr.io/deepgram-public/deepgram-self-hosted-starter/deployer/tester
         tester.image.tag:
           type: TAG
-          default: 1.5.2
+          default: 1.6.0
 
 properties:
   name:


### PR DESCRIPTION
## Summary
- Rebuilds all 4 marketplace images with latest Google base images to address CVE-2026-33186 flagged by GCP Marketplace scanner
- Adds `apt-get dist-upgrade` to the deployer's final stage (`deployer_helm`), which was previously only patched in the discarded build stage
- Version bump from 1.2.0 to 1.2.1 via `bump.sh`

## Context
GCP Marketplace flagged CVE-2026-33186 in both the deployer and ubbagent images. Both are built entirely on Google-provided base images. The ubbagent is mirrored verbatim from Google's registry — no Dockerfile exists. Images have already been built and pushed as 1.2.1.

## Test plan
- [x] `build.sh` completed successfully, all 4 images pushed with `1.2.1` and `1.2` tags
- [ ] Resubmit listing in GCP Producer Portal
- [ ] Verify GCP scanner clears CVE-2026-33186 on deployer image
- [ ] If ubbagent CVE persists, file exception with Google (their upstream image)